### PR TITLE
Cleanup casadi-ipopt-hsl.md

### DIFF
--- a/doc/casadi-ipopt-hsl.md
+++ b/doc/casadi-ipopt-hsl.md
@@ -2,16 +2,16 @@
 
 This guide should help you to install CasADi with IPOPT and HSL support.
 
-0. Install some dependencies `sudo apt-get install build-essential gfortran liblapack-dev libmetis-dev libopenblas-dev` 
+0. Install some dependencies `sudo apt-get install build-essential gfortran liblapack-dev libmetis-dev libopenblas-dev` and remove the ipopt installed with apt to avoid conflicts with the one that you will install `sudo apt-get remove coinor-libipopt-dev`
 1. `mkdir -p  ~/robot-code/CoinIpopt && cd ~/robot-code/CoinIpopt`
 2. Get [`coinbrew`](https://github.com/coin-or/Ipopt#using-coinbrew)  
    1. `wget https://raw.githubusercontent.com/coin-or/coinbrew/master/coinbrew`
    2. `chmod u+x coinbrew`
-3. Run `./coinbrew Ipopt` and follow the instruction to fetch IPOPT and all the dependencies (Today the latest version of IPOPT is `3.13.4`)
+3. Run `./coinbrew Ipopt` and follow the instruction to fetch IPOPT and all the dependencies
 4. `mkdir install`
-5. Build ipot `./coinbrew build Ipopt --prefix=install --test --no-prompt --verbosity=3` (have a :coffee:)
-6. Obtain an archive with HSL source code from http://www.hsl.rl.ac.uk/ipopt/. (I'm currently using `coinhsl-2019.05.21`)
-7. Unzip the folder `coinhsl-2019.05.21.zip` into `~/robot-code/CoinIpopt/ThirdParty/HSL/` and rename it `coinhsl`.
+5. Build ipopt `./coinbrew build Ipopt --prefix=install --test --no-prompt --verbosity=3` (have a :coffee:)
+6. Obtain an archive with HSL source code from http://www.hsl.rl.ac.uk/ipopt/. (That for example is named `coinhsl-YYYY.MM.DD`)
+7. Unzip the folder `coinhsl-YYYY.MM.DD.zip` into `~/robot-code/CoinIpopt/ThirdParty/HSL/` and rename it `coinhsl`.
 9. `cd ~/robot-code/CoinIpopt` 
 10. Build ipopt `./coinbrew build Ipopt --prefix=install --test --no-prompt --verbosity=3` (have a :coffee:)
 11. Run `./coinbrew install Ipopt --no-prompt`


### PR DESCRIPTION
* Remove "as today" and dates commenst that will always be outdated
* Document to install apt's ipopt to avoid conflicts between apt's ipopt and coinbrew's ipopt